### PR TITLE
fix(client): 유저의 prompt를 불러오지 못하는 이슈를 수정합니다

### DIFF
--- a/apps/client/components/Layout/AppLayout/Nav/index.tsx
+++ b/apps/client/components/Layout/AppLayout/Nav/index.tsx
@@ -17,7 +17,7 @@ const Nav = () => {
   const { isDetail } = getRouterState(pathname);
   const { typography, colors } = useTheme();
   const { data: me } = useQueryMe();
-  const { installable, openInstallPrompt, isPWA } = useBeforeInstallPrompt();
+  const { isPWA, ...rest } = useBeforeInstallPrompt();
   const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
 
@@ -126,7 +126,7 @@ const Nav = () => {
       </header>
       {isNoticeModalOpen && <NoticeBottomSheet onClose={closeNoticeModal} />}
       {isDownloadModalOpen && (
-        <DownloadBottomSheet onClose={closeDownloadModal} />
+        <DownloadBottomSheet onClose={closeDownloadModal} {...rest} />
       )}
     </>
   );

--- a/apps/client/components/common/BottomSheet/Download/DownloadBottomSheet.tsx
+++ b/apps/client/components/common/BottomSheet/Download/DownloadBottomSheet.tsx
@@ -3,12 +3,14 @@ import DownloadContainer from './DownloadContainer';
 
 interface Props {
   onClose: () => void;
+  installable: boolean;
+  openInstallPrompt: () => void;
 }
 
-const DownloadBottomSheet = ({ onClose }: Props) => {
+const DownloadBottomSheet = ({ onClose, ...rest }: Props) => {
   return (
     <BottomSheet onClose={onClose}>
-      <DownloadContainer />
+      <DownloadContainer {...rest} />
     </BottomSheet>
   );
 };

--- a/apps/client/components/common/BottomSheet/Download/DownloadContainer.tsx
+++ b/apps/client/components/common/BottomSheet/Download/DownloadContainer.tsx
@@ -1,6 +1,5 @@
 import { css, useTheme } from '@emotion/react';
 import Link from 'next/link';
-import { useBeforeInstallPrompt } from '~/hooks';
 import getUserDevice from '~/utils/getUserDevice';
 
 const CHROME_INTENT_URL =
@@ -17,9 +16,13 @@ const createMesage = (userDevice: ReturnType<typeof getUserDevice>) => {
   }
 };
 
-const DownloadContainer = () => {
+interface Props {
+  installable: boolean;
+  openInstallPrompt: () => void;
+}
+
+const DownloadContainer = ({ installable, openInstallPrompt }: Props) => {
   const { colors } = useTheme();
-  const { installable, openInstallPrompt } = useBeforeInstallPrompt();
   const userDevice = getUserDevice();
 
   return (


### PR DESCRIPTION
# 작업 내용
- 다른 컴포넌트에서 동일한 훅을 호출하여 상태를 공유하려고 하였는데, 당연히 문제가 발생하였습니다.
- 이 문제를 해결하기 위해 상위 nav에서만 훅을 호출하고 해당 상태를 props로 내려주는 방식으로 해결했습니다.

# 핵심 내용

# 기타 사항
