### PR TITLE
fix: 기존 news 상세 페이지를 최신 순 30개만 생성하도록 제한합니다

### DIFF
--- a/apps/client/pages/news/[id].tsx
+++ b/apps/client/pages/news/[id].tsx
@@ -55,7 +55,7 @@ export const getStaticProps: GetStaticProps = async (
 
 export const getStaticPaths = async () => {
   const news = await getNews();
-  const paths = news.map(({ id }) => ({
+  const paths = news.slice(0, 30).map(({ id }) => ({
     params: { id },
   }));
 


### PR DESCRIPTION
# 작업 내용
- 기존 news 상세 페이지를 최신 순 30개만 생성하도록 제한합니다

# 핵심 내용
- 기존 news 상세 페이지를 최신 순 30개만 생성하도록 제한합니다

# 기타 사항
issue #76 